### PR TITLE
Add i18n translations for services section

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -39,6 +39,22 @@
     "getStarted": "Get Started",
     "watchVideo": "Watch video"
   },
+  "services": {
+    "sectionLabel": "Services We Offer",
+    "sectionHeading": "<span>Get Best</span> Advertiser <span>In Your Side Pocket</span>",
+    "item1": {
+      "title": "Friendly dashboard & Cool Interface.",
+      "text": "Finding the perfect learning tool for Flash is a daunting task to any novice web developer."
+    },
+    "item2": {
+      "title": "Download Free Song For Ipod",
+      "text": "Finding the perfect learning tool for Flash is a daunting task to any novice web developer."
+    },
+    "item3": {
+      "title": "Are You Famous Or Focused",
+      "text": "Finding the perfect learning tool for Flash is a daunting task to any novice web developer."
+    }
+  },
   "subscribe": {
     "title": "Getting connected with us & <br> for the update.",
     "cta": "Subscribe Now"

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -39,6 +39,22 @@
     "getStarted": "Get Started",
     "watchVideo": "Watch video"
   },
+  "services": {
+    "sectionLabel": "Servicios que ofrecemos",
+    "sectionHeading": "<span>Consigue el mejor</span> anunciante <span>en tu bolsillo</span>",
+    "item1": {
+      "title": "Tablero amigable e interfaz genial",
+      "text": "Encontrar la herramienta de aprendizaje perfecta para Flash es una tarea ardua para cualquier desarrollador web principiante."
+    },
+    "item2": {
+      "title": "Descarga canciones gratis para iPod",
+      "text": "Encontrar la herramienta de aprendizaje perfecta para Flash es una tarea ardua para cualquier desarrollador web principiante."
+    },
+    "item3": {
+      "title": "¿Eres famoso o enfocado?",
+      "text": "Encontrar la herramienta de aprendizaje perfecta para Flash es una tarea ardua para cualquier desarrollador web principiante."
+    }
+  },
   "subscribe": {
     "title": "Getting connected with us & <br> for the update.",
     "cta": "Subscribe Now"

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -39,6 +39,22 @@
     "getStarted": "Começar",
     "watchVideo": "Assistir vídeo"
   },
+  "services": {
+    "sectionLabel": "Serviços que oferecemos",
+    "sectionHeading": "<span>Consiga o melhor</span> anunciante <span>no seu bolso</span>",
+    "item1": {
+      "title": "Painel amigável e interface legal",
+      "text": "Encontrar a ferramenta de aprendizado perfeita para Flash é uma tarefa assustadora para qualquer desenvolvedor web iniciante."
+    },
+    "item2": {
+      "title": "Baixe música grátis para iPod",
+      "text": "Encontrar a ferramenta de aprendizado perfeita para Flash é uma tarefa assustadora para qualquer desenvolvedor web iniciante."
+    },
+    "item3": {
+      "title": "Você é famoso ou focado?",
+      "text": "Encontrar a ferramenta de aprendizado perfeita para Flash é uma tarefa assustadora para qualquer desenvolvedor web iniciante."
+    }
+  },
   "subscribe": {
     "title": "Conectando-se conosco e <br> recebendo atualizações.",
     "cta": "Inscreva-se Agora"

--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@
             <div class="row justify-content-center">
                 <div class="col-lg-6 col-md-8">
                     <div class="section-title section-title-2 text-center">
-                        <span>Service We Offer</span>
-                        <h3 class="title"><span>Get Best</span> Advertiser <span>In Your Side Pocket</span></h3>
+                        <span data-i18n="services.sectionLabel"></span>
+                        <h3 class="title" data-i18n="services.sectionHeading"></h3>
                     </div> <!-- SECTION TITLE -->
                 </div>
             </div> <!-- row -->
@@ -217,8 +217,8 @@
                                 <path fill="#3b36de" d="M32.458 32.814l8.709-8.706c.915-.914 2.399-.914 3.314 0 .915.916.915 2.399 0 3.314L34.115 37.783c-.915.915-2.4.915-3.315 0l-4.654-4.652-7.313 7.31c-.915.915-2.399.915-3.314 0s-.915-2.399 0-3.313l8.97-8.967c.915-.915 2.4-.914 3.315 0l4.654 4.653z" />
                             </g>
                         </svg>
-                        <h4 class="title">Friendly dashboard & Cool Interface.</h4>
-                        <p>Finding the perfect learning tool for Flash is a daunting task to any novice web developer.</p>
+                        <h4 class="title" data-i18n="services.item1.title"></h4>
+                        <p data-i18n="services.item1.text"></p>
                         <div class="services-overlay-1">
                             <img src="assets/images/overly-1.svg" alt="">
                         </div>
@@ -238,8 +238,8 @@
                                 <path fill="#3F3D56" d="M46.355 0h-36.32v15h3.742V3.75H41.84v13.125h13.095V56.25H23.131V60h35.545V12.349L46.356 0zm-.774 13.125V4.526l8.579 8.599h-8.58z" />
                             </g>
                         </svg>
-                        <h4 class="title">Download Free Song For Ipod</h4>
-                        <p>Finding the perfect learning tool for Flash is a daunting task to any novice web developer.</p>
+                        <h4 class="title" data-i18n="services.item2.title"></h4>
+                        <p data-i18n="services.item2.text"></p>
                         <div class="services-overlay-1">
                             <img src="assets/images/overly-1.svg" alt="">
                         </div>
@@ -261,8 +261,8 @@
                                 <path fill="#3F3D56" d="M30 12.5c-1.035 0-1.875-.84-1.875-1.875v-8.75C28.125.84 28.965 0 30 0c1.035 0 1.875.84 1.875 1.875v8.75c0 1.035-.84 1.875-1.875 1.875zM58.125 31.875h-8.75c-1.035 0-1.875-.84-1.875-1.875 0-1.035.84-1.875 1.875-1.875h8.75c1.035 0 1.875.84 1.875 1.875 0 1.035-.84 1.875-1.875 1.875zM30 60c-1.035 0-1.875-.84-1.875-1.875v-8.75c0-1.035.84-1.875 1.875-1.875 1.035 0 1.875.84 1.875 1.875v8.75C31.875 59.16 31.035 60 30 60zM10.625 31.875h-8.75C.84 31.875 0 31.035 0 30c0-1.035.84-1.875 1.875-1.875h8.75c1.035 0 1.875.84 1.875 1.875 0 1.035-.84 1.875-1.875 1.875z" />
                             </g>
                         </svg>
-                        <h4 class="title">Are You Famous Or Focused</h4>
-                        <p>Finding the perfect learning tool for Flash is a daunting task to any novice web developer.</p>
+                        <h4 class="title" data-i18n="services.item3.title"></h4>
+                        <p data-i18n="services.item3.text"></p>
                         <div class="services-overlay-1">
                             <img src="assets/images/overly-1.svg" alt="">
                         </div>


### PR DESCRIPTION
## Summary
- localize services section in index.html with `data-i18n`
- add Spanish, English and Portuguese strings for services section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926da33228832baa4341869affd42e