### PR TITLE
Add English localized homepage

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -1,0 +1,1552 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <!-- Basics -->
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+  <!-- Title + Description -->
+  <title>Medical Software (EHR) for Clinics and Practices | SyncroClinic</title>
+  <meta name="description" content="Cloud-based medical software for clinics: electronic health records, scheduling, prescriptions, WhatsApp reminders, and billing. Try it free for 15 days.">
+
+  <!-- Canonical + Hreflang (matching the EN/PT versions in the nav) -->
+  <link rel="canonical" href="https://syncroclinic.com/index-en.html">
+  <link rel="alternate" href="https://syncroclinic.com/" hreflang="es">
+  <link rel="alternate" href="https://syncroclinic.com/index-en.html" hreflang="en">
+  <link rel="alternate" href="https://syncroclinic.com/index-pt.html" hreflang="pt">
+  <link rel="alternate" href="https://syncroclinic.com/index-en.html" hreflang="x-default">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:site_name" content="SyncroClinic">
+  <meta property="og:title" content="Medical Software (EHR) for Clinics and Practices | SyncroClinic">
+  <meta property="og:description" content="Electronic health records, scheduling, prescriptions, WhatsApp reminders, and billing. Try it free for 15 days.">
+  <meta property="og:url" content="https://syncroclinic.com/index-en.html">
+  <meta property="og:image" content="https://syncroclinic.com/assets/images/banner-thumb-1.png">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Medical Software (EHR) for Clinics and Practices | SyncroClinic">
+  <meta name="twitter:description" content="Electronic health records, scheduling, prescriptions, and WhatsApp reminders. Try it free for 15 days.">
+  <meta name="twitter:image" content="https://syncroclinic.com/assets/images/banner-thumb-1.png">
+
+  <!-- Favicon -->
+  <link rel="shortcut icon" href="assets/images/favicon.ico" type="image/png">
+
+  <!-- CSS (existing) -->
+  <link rel="stylesheet" href="https://cdn.lineicons.com/3.0/lineicons.css">
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css">
+  <link rel="stylesheet" href="assets/css/font-awesome.min.css">
+  <link rel="stylesheet" href="assets/css/magnific-popup.css">
+  <link rel="stylesheet" href="assets/css/slick.css">
+  <link rel="stylesheet" href="assets/css/animate.min.css">
+  <link rel="stylesheet" href="assets/css/custom-animation.css">
+  <link rel="stylesheet" href="assets/css/default.css">
+  <link rel="stylesheet" href="assets/css/style.css">
+
+  <!-- Schema.org (SoftwareApplication + Organization) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "SyncroClinic",
+    "applicationCategory": "BusinessApplication",
+    "operatingSystem": "Web",
+    "url": "https://syncroclinic.com/",
+    "description": "Cloud-based medical software for clinics: electronic health records, scheduling, prescriptions, and WhatsApp reminders.",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Vozocial S.A.",
+      "url": "https://syncroclinic.com/",
+      "email": "info@syncroclinic.com",
+      "telephone": "+50760708205"
+    }
+  }
+  </script>
+</head>
+
+
+<body>
+
+    <!--====== PRELOADER PART START ======-->
+
+    <div class="preloader" id="preloader">
+        <div class="three ">
+            <div class="loader" id="loader">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+        </div>
+    </div>
+
+    <!--====== PRELOADER PART START ======-->
+
+    <!--====== HEADER PART START ======-->
+
+    <header class="header-area header-2-area">
+        <div class="header-nav">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-12">
+                        <div class="navigation">
+<!-- Language Selector -->
+<div class="text-right" style="font-size: 14px; padding-top: 0px !important;">
+  <i class="lni lni-world" style="color: white; margin-right: 8px;"></i>
+  <a href="index.html" class="lang-link mr-3" style="color: white !important;">ES</a>
+  <a href="index-en.html" class="lang-link mr-3" style="color: white !important;">EN</a>
+  <a href="index-pt.html" class="lang-link" style="color: white !important;">PT</a>
+</div>
+
+<!-- End Language Selector -->
+
+
+
+                            <nav class="navbar navbar-expand-lg navbar-light ">
+                                <a class="navbar-brand" href="index.html"><img src="assets/images/logo-1.png" alt="" style="width: 200px;"></a> <!-- logo -->
+                                <a class="navbar-brand-2" href="index.html"><img src="assets/images/logo-2.png" alt="" style="width: 200px;"></a> <!-- logo -->
+                                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                                    <span class="toggler-icon"></span>
+                                    <span class="toggler-icon"></span>
+                                    <span class="toggler-icon"></span>
+                                </button> <!-- navbar toggler -->
+
+                                <div class="collapse navbar-collapse sub-menu-bar" id="navbarSupportedContent">
+                                    <ul class="navbar-nav ml-auto">
+                                      <li class="nav-item">
+  <a class="nav-link"
+       href="https://app.syncroclinic.com/register-clinic"
+       target="_blank"
+       rel="noopener noreferrer">
+       Free Trial
+    </a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="#demo">Request Demo</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" href="#precios">Pricing</a>
+    </li>
+    <li class="nav-item">
+            <a class="nav-link"
+       href="https://wa.me/50760708205?text=Hello,+I'm+interested+in+the+SyncroClinic+system"
+       target="_blank"
+       rel="noopener noreferrer">
+       WhatsApp
+    </a>
+    </li>
+                                    </ul>
+                                </div> <!-- navbar collapse -->
+<div class="navbar-btn d-none d-sm-block">
+    <a class="main-btn" href="https://app.syncroclinic.com/register-clinic" target="_blank">Start Free</a>
+</div>
+
+                            </nav>
+                        </div> <!-- navigation -->
+                    </div>
+                </div> <!-- row -->
+            </div>
+        </div>
+    </header>
+
+    <!--====== HEADER PART ENDS ======-->
+
+    <!--====== BANNER PART START ======-->
+
+    <section class="banner-area banner-2-area d-flex align-items-center">
+        <div class="banner__bg"></div>
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-7">
+                    <div class="banner-content">
+                        <h1 class="title">
+                        Discover the Smartest <span>Electronic Health Record</span> Software
+                        </h1>
+<p class="text tagline-mobile" style="font-style: italic; font-size: 20px; padding-bottom: 30px !important; margin-top: -30px !important;">
+  Your patients <strong style="color: #FFD700;">won't forget</strong> when you remind them—happy patients, growing practices.
+</p>
+
+
+
+<h3 class="title" style="font-size: 20px; line-height: 1.2;">
+  Organize and automate your clinic from anywhere
+</h3>
+
+
+<p style="font-size: 16px; color: white;">
+  <span style="color: white; font-weight: bold; font-size: 18px; margin-right: 6px;">✔</span>
+  Manage patients, appointments, prescriptions, and billing in one easy-to-use system. No installations required. <strong style="color: #FFD700;">Free for 15 days.</strong>
+</p>
+
+
+
+
+                       
+                      <ul>
+                            <li><a class="main-btn" href="https://app.syncroclinic.com/register-clinic">Free Demo</a></li>
+                            <li><a class="play video-popup" href="https://www.youtube.com/watch?v=_Hp_dI0DzY4">
+                                <div class="play-btn"><img src="assets/images/play.svg" alt=""></div> Watch video
+                            </a></li>
+                        </ul>
+                    </div> <!-- banner content -->
+                </div>
+            </div> <!-- row -->
+        </div>
+        <div class="banner-shaps-item">
+            <div class="banner-shape">
+                <img src="assets/images/banner-shape.svg" alt="">
+            </div>
+            <div class="banner-thumb animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="300ms">
+                <img src="assets/images/banner-thumb-1.png" alt="main medical software screen">
+            </div>
+            <div class="banner-thumb-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="350ms">
+                <img src="assets/images/banner-thumb-2.png" alt="mobile app view">
+            </div>
+        </div>
+    </section>
+
+    <!--====== BANNER PART ENDS ======-->
+
+    <!--====== SERVICES PART START ======-->
+
+<section class="sevices-area">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-6 col-md-8">
+                    <div class="section-title section-title-2 text-center">
+                        <span style="line-height: 1.2; color: #d60aff;">What does our system include?</span>
+                                           <p class="text" style="padding-top: 20px;">
+                      A complete digital platform to manage your patients' medical history from any device. The ideal <strong>electronic health record software</strong> for modern clinics.
+                    </p>
+
+<h2 id="funciones" class="title"><span>Key features of the</span> most comprehensive Electronic Health Record <span>software</span></h2>
+
+
+                    </div> <!-- SECTION TITLE -->
+                </div>
+            </div> <!-- row -->
+<div class="row justify-content-center">
+
+    <!-- COMPLETE MEDICAL HISTORY -->
+    <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="sevices-item services-2-item mt-30">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#3b36de" className="size-6">
+  <path fillRule="evenodd" d="M7.502 6h7.128A3.375 3.375 0 0 1 18 9.375v9.375a3 3 0 0 0 3-3V6.108c0-1.505-1.125-2.811-2.664-2.94a48.972 48.972 0 0 0-.673-.05A3 3 0 0 0 15 1.5h-1.5a3 3 0 0 0-2.663 1.618c-.225.015-.45.032-.673.05C8.662 3.295 7.554 4.542 7.502 6ZM13.5 3A1.5 1.5 0 0 0 12 4.5h4.5A1.5 1.5 0 0 0 15 3h-1.5Z" clipRule="evenodd" />
+  <path fillRule="evenodd" d="M3 9.375C3 8.339 3.84 7.5 4.875 7.5h9.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 0 1 3 20.625V9.375ZM6 12a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V12Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 15a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V15Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75ZM6 18a.75.75 0 0 1 .75-.75h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H6.75a.75.75 0 0 1-.75-.75V18Zm2.25 0a.75.75 0 0 1 .75-.75h3.75a.75.75 0 0 1 0 1.5H9a.75.75 0 0 1-.75-.75Z" clipRule="evenodd" />
+</svg>
+
+                
+            <h3 class="title">Complete Medical History</h3>
+            <p>Review every patient's record with diagnoses, treatments, medical history, vitals, and past exams from a single screen.</p>
+
+            <div class="services-overlay-1"><img src="assets/images/overly-1.svg" alt=""></div>
+            <div class="services-overlay-2"><img src="assets/images/overly-2.svg" alt=""></div>
+            <div class="services-overlay-3"><img src="assets/images/overly-3.svg" alt=""></div>
+        </div>
+    </div>
+
+    <!-- CONSULTAS + IA -->
+    <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="sevices-item services-2-item mt-30">
+ <svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="#d60aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-brain-circuit-icon lucide-brain-circuit"><path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"/><path d="M9 13a4.5 4.5 0 0 0 3-4"/><path d="M6.003 5.125A3 3 0 0 0 6.401 6.5"/><path d="M3.477 10.896a4 4 0 0 1 .585-.396"/><path d="M6 18a4 4 0 0 1-1.967-.516"/><path d="M12 13h4"/><path d="M12 18h6a2 2 0 0 1 2 2v1"/><path d="M12 8h8"/><path d="M16 8V5a2 2 0 0 1 2-2"/><circle cx="16" cy="13" r=".5"/><circle cx="18" cy="3" r=".5"/><circle cx="20" cy="21" r=".5"/><circle cx="20" cy="8" r=".5"/></svg>
+            
+            
+            <h3 class="title">Medical Visits + AI</h3>
+            <p>Enter symptoms and receive AI-powered diagnostic suggestions. Enhance clinical care with real-time technology support.</p>
+
+            <div class="services-overlay-1"><img src="assets/images/overly-1.svg" alt=""></div>
+            <div class="services-overlay-2"><img src="assets/images/overly-2.svg" alt=""></div>
+            <div class="services-overlay-3"><img src="assets/images/overly-3.svg" alt=""></div>
+        </div>
+    </div>
+
+    <!-- ATTACH EXAMS FROM PHONE -->
+    <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="sevices-item services-2-item mt-30">
+            <svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="#3b36de" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-paperclip-icon lucide-paperclip"><path d="m16 6-8.414 8.586a2 2 0 0 0 2.829 2.829l8.414-8.586a4 4 0 1 0-5.657-5.657l-8.379 8.551a6 6 0 1 0 8.485 8.485l8.379-8.551"/></svg>
+            <h3 class="title">Attach Exams from Your Phone</h3>
+            <p>Scan exam results or capture them with your phone's camera to add them to the patient's chart in real time.</p>
+
+            <div class="services-overlay-1"><img src="assets/images/overly-1.svg" alt=""></div>
+            <div class="services-overlay-2"><img src="assets/images/overly-2.svg" alt=""></div>
+            <div class="services-overlay-3"><img src="assets/images/overly-3.svg" alt=""></div>
+        </div>
+    </div>
+
+    <!-- MEDICAL AND EXAM PRESCRIPTIONS -->
+    <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="sevices-item services-2-item mt-30">
+           <svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="#d60aff" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-pill-icon lucide-pill"><path d="m10.5 20.5 10-10a4.95 4.95 0 1 0-7-7l-10 10a4.95 4.95 0 1 0 7 7Z"/><path d="m8.5 8.5 7 7"/></svg>
+            <h3 class="title">Fast Prescriptions</h3>
+            <p>Prescribe medications and tests in seconds with automated templates and default options that speed up every consultation.</p>
+
+            <div class="services-overlay-1"><img src="assets/images/overly-1.svg" alt=""></div>
+            <div class="services-overlay-2"><img src="assets/images/overly-2.svg" alt=""></div>
+            <div class="services-overlay-3"><img src="assets/images/overly-3.svg" alt=""></div>
+        </div>
+    </div>
+
+    <!-- RECETAS EN PDF -->
+    <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="sevices-item services-2-item mt-30">
+<svg xmlns="http://www.w3.org/2000/svg" width="60" height="60" viewBox="0 0 24 24" fill="none" stroke="#3b36de" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-down-icon lucide-file-down"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M12 18v-6"/><path d="m9 15 3 3 3-3"/></svg>
+            <h3 class="title">Downloadable PDF Prescriptions</h3>
+            <p>Create branded medical prescriptions ready to print or send via email or WhatsApp. Fully professional and exportable.</p>
+
+            <div class="services-overlay-1"><img src="assets/images/overly-1.svg" alt=""></div>
+            <div class="services-overlay-2"><img src="assets/images/overly-2.svg" alt=""></div>
+            <div class="services-overlay-3"><img src="assets/images/overly-3.svg" alt=""></div>
+        </div>
+    </div>
+
+</div>
+</div>
+</section>
+
+    <!--====== SERVICES PART ENDS ======-->
+
+   <!--====== ADVERTISER PART START ======-->
+<section class="advertiser-area advertiser-2-area">
+    <div class="advertiser-bg"></div>
+    <div class="container">
+<!-- Section: Access to the Medical Record -->
+<div class="advertiser-item">
+    <div class="row align-items-center">
+        <div class="col-lg-5">
+            <div class="advertiser-thumb animated wow fadeInLeft" data-wow-duration="1500ms" data-wow-delay="100ms">
+                <img src="assets/images/advertiser-thumb-5.png" alt="">
+                <div class="thumb">
+                    <img src="assets/images/advertiser-bar-1.png" alt="advertiser">
+                </div>
+                <div class="advertiser-bg-shape">
+                    <img src="assets/images/advertiser-shape-4.png" alt="">
+                    <div class="round-shape"></div>
+                    <div class="advertiser-shape-1">
+                        <img src="assets/images/advertiser-shape-1.png" alt="">
+                    </div>
+                    <div class="advertiser-shape-2">
+                        <img src="assets/images/advertiser-shape-2.png" alt="">
+                    </div>
+                </div>
+            </div> <!-- advertiser thumb -->
+        </div>
+        <div class="col-lg-7">
+            <div class="advertiser-content pl-65">
+<h2 id="historial" class="title"><span>Complete Medical Record</span> instantly <span>with a quick patient search</span></h2>
+
+                <p>Simply enter the patient's name or ID number to open their centralized health record—from reason for visit and initial symptoms to diagnoses, exams, and prescribed treatments.</p>
+                <ul class="feature-list">
+                    <li><img src="assets/images/check-2.svg" alt="Fast search">Search by name or ID number</li>
+                    <li><img src="assets/images/check-2.svg" alt="Complete summary">See reason for visit and preliminary diagnosis</li>
+                    <li><img src="assets/images/check-2.svg" alt="Exams">View exams uploaded at the clinic or externally</li>
+                    <li><img src="assets/images/check-2.svg" alt="Treatments">Display prescribed medications and lab orders</li>
+                    <li><img src="assets/images/check-2.svg" alt="Final diagnosis">Access the final diagnosis with a single click</li>
+                    <li><img src="assets/images/check-2.svg" alt="Cloud based">Records always available from any device</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+        <!-- Section 1: Sending symptoms to AI -->
+        <div class="advertiser-item">
+            <div class="row align-items-center">
+                <div class="col-lg-5">
+                    <div class="advertiser-thumb animated wow fadeInLeft" data-wow-duration="1500ms" data-wow-delay="100ms">
+                        <img src="assets/images/advertiser-thumb-1.png" alt="">
+                        <div class="thumb">
+                            <img src="assets/images/advertiser-bar-1.png" alt="advertiser">
+                        </div>
+                        <div class="advertiser-bg-shape">
+                            <img src="assets/images/advertiser-shape-4.png" alt="">
+                            <div class="round-shape"></div>
+                            <div class="advertiser-shape-1">
+                                <img src="assets/images/advertiser-shape-1.png" alt="">
+                            </div>
+                            <div class="advertiser-shape-2">
+                                <img src="assets/images/advertiser-shape-2.png" alt="">
+                            </div>
+                        </div>
+                    </div> <!-- advertiser thumb -->
+                </div>
+                <div class="col-lg-7">
+                    <div class="advertiser-content pl-65">
+<h2 id="diagnostico-ia" class="title"><span>AI Diagnosis</span> based on symptoms <span>entered by the physician</span></h2>
+
+                        <p>The system collects the patient's symptoms from the clinical form and sends them through the OpenAI API to obtain an automated diagnostic suggestion. It does not replace the doctor, but it provides a fast and helpful reference.</p>
+                        <ul class="feature-list">
+                            <li><img src="assets/images/check-2.svg" alt="AI submission">Automatically pulls symptoms from the form</li>
+                            <li><img src="assets/images/check-2.svg" alt="OpenAI API">Sends data to OpenAI with secure integration</li>
+                            <li><img src="assets/images/check-2.svg" alt="Suggested diagnosis">Receives a non-binding diagnostic suggestion</li>
+                            <li><img src="assets/images/check-2.svg" alt="Clinical support">Provides clinical support, not a final diagnosis</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section 2: Suggested diagnosis result -->
+        <div class="advertiser-item item-2">
+            <div class="row align-items-center">
+                <div class="col-lg-7">
+                    <div class="advertiser-content pr-65">
+                        <h2 class="title"><span>See the suggested diagnosis</span> on screen <span>with a single click</span></h2>
+                        <p>After processing the symptoms, the AI-generated result appears automatically in the physician's form. This field is editable and optional, serving as a guide or reference for the clinician's final diagnosis.</p>
+                        <ul>
+                            <li><img src="assets/images/check-2.svg" alt="Editable field">Suggested diagnosis visible on screen</li>
+                            <li><img src="assets/images/check-2.svg" alt="Optional">Optional for the physician to use</li>
+                            <li><img src="assets/images/check-2.svg" alt="Save time">Optimize every visit with automated support</li>
+                            <li><img src="assets/images/check-2.svg" alt="Integrated AI">AI integrated directly into the clinical system</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="col-lg-5">
+                    <div class="advertiser-thumb text-right animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="100ms">
+                        <img src="assets/images/advertiser-thumb-2.png" alt="">
+                        <div class="advertiser-bg-shape">
+                            <img src="assets/images/advertiser-shape-4.png" alt="">
+                            <div class="round-shape"></div>
+                            <div class="advertiser-shape-1">
+                                <img src="assets/images/advertiser-shape-1.png" alt="">
+                            </div>
+                            <div class="advertiser-shape-2">
+                                <img src="assets/images/advertiser-shape-2.png" alt="">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Section 3: Attach exams from mobile with QR -->
+        <div class="advertiser-item item-3">
+            <div class="row align-items-center">
+                <div class="col-lg-5">
+                    <div class="advertiser-thumb animated wow fadeInLeft" data-wow-duration="1500ms" data-wow-delay="100ms">
+                        <img src="assets/images/advertiser-thumb-3.png" alt="">
+                        <div class="advertiser-bg-shape">
+                            <img src="assets/images/advertiser-shape-4.png" alt="">
+                            <div class="round-shape"></div>
+                            <div class="advertiser-shape-2">
+                                <img src="assets/images/advertiser-shape-2.png" alt="">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-7">
+                    <div class="advertiser-content pl-65">
+                       <h2 id="adjuntos-qr" class="title"><span>Attach exams</span> with your phone <span>from anywhere</span></h2>
+
+                        <p>Physicians can scan a QR code from the computer to capture photos on their phone and upload exams directly to the visit. They can also add files from a tablet or mobile device without scanning. Everything is saved in the cloud and available in the patient's history.</p>
+                        <ul>
+                            <li><img src="assets/images/check-2.svg" alt="QR scan">Scan a QR code to upload photos from your phone</li>
+                            <li><img src="assets/images/check-2.svg" alt="Direct attachments">Attach exams to every medical visit</li>
+                            <li><img src="assets/images/check-2.svg" alt="Access on any device">Available from desktop, tablet, or mobile</li>
+                            <li><img src="assets/images/check-2.svg" alt="Cloud exams">Exams are stored in the cloud and accessible in the chart</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</section>
+<!--====== ADVERTISER PART ENDS ======-->
+
+
+    <!--====== WHAT WE DO PART START ======-->
+
+    <section class="what-we-do-area what-we-do-2-area">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-7">
+                    <div class="section-title section-title-2 text-center">
+<span>What can our system do?</span>
+<h2 id="que-hace" class="title">Key features of the <span>Electronic Health Record Software</span> for your practice</h2>
+
+
+                    </div> <!-- SECTION TITLE -->
+                </div>
+            </div> <!-- row -->
+            <div class="row justify-content-center">
+                <div class="col-lg-4 col-md-6 col-sm-8">
+                    <div class="what-we-do-item what-we-do-2-item text-center mt-30">
+                        <div class="icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="97" viewBox="0 0 100 97">
+                                <g fill="none">
+                                    <path fill="#3b36de" d="M64.358 24.262c2.687 0 4.873-2.211 4.873-4.928s-2.186-4.928-4.873-4.928c-2.688 0-4.874 2.21-4.874 4.928 0 1.11.365 2.135.98 2.96l-8.007 11.313c-.478-.158-.987-.245-1.517-.245-1.28 0-2.447.502-3.317 1.322l-5.337-3.062c.07-.335.109-.681.109-1.036 0-2.718-2.186-4.928-4.873-4.928-2.687 0-4.873 2.21-4.873 4.928 0 .355.038.701.109 1.036l-5.337 3.062c-.87-.82-2.037-1.322-3.317-1.322-2.687 0-4.873 2.21-4.873 4.928 0 2.717 2.186 4.928 4.873 4.928 2.687 0 4.873-2.211 4.873-4.928 0-.356-.038-.702-.11-1.036l5.338-3.063c.87.82 2.036 1.323 3.317 1.323 1.28 0 2.446-.503 3.317-1.323l5.337 3.063c-.071.334-.11.68-.11 1.036 0 2.717 2.187 4.928 4.874 4.928s4.873-2.21 4.873-4.928c0-1.11-.365-2.135-.98-2.96l8.007-11.314c.478.158.988.246 1.518.246zm0-6.9c1.074 0 1.949.885 1.949 1.972s-.875 1.97-1.95 1.97c-1.074 0-1.949-.883-1.949-1.97s.875-1.971 1.95-1.971zM24.103 40.262c-1.074 0-1.949-.885-1.949-1.972s.875-1.97 1.95-1.97c1.074 0 1.949.883 1.949 1.97s-.875 1.972-1.95 1.972zm13.418-7.704c-1.074 0-1.949-.885-1.949-1.972 0-1.086.875-1.97 1.95-1.97 1.074 0 1.949.884 1.949 1.97 0 1.087-.875 1.972-1.95 1.972zM50.94 40.26c-1.075 0-1.95-.885-1.95-1.972s.875-1.97 1.95-1.97 1.949.883 1.949 1.97-.875 1.972-1.95 1.972z" />
+                                    <path fill="#000" d="M82.182 71.81H4.163c-.672 0-1.22-.548-1.22-1.22V9.922c0-.672.548-1.219 1.22-1.219h6.938c.813 0 1.472-.658 1.472-1.47 0-.812-.659-1.47-1.472-1.47H4.163C1.868 5.762 0 7.627 0 9.921V70.59c0 2.294 1.868 4.16 4.163 4.16h10.148v3.237c0 1.843 1.501 3.343 3.346 3.343H32.39L25.455 94.86c-.371.723-.085 1.609.638 1.979.215.11.444.162.67.162.535 0 1.05-.292 1.311-.8l7.623-14.87h16.272L59.59 96.2c.26.508.776.8 1.311.8.226 0 .455-.052.67-.162.723-.37 1.01-1.256.639-1.98L55.276 81.33h14.732c1.845 0 3.346-1.5 3.346-3.343V74.75h8.828c.813 0 1.472-.658 1.472-1.47 0-.813-.66-1.47-1.472-1.47zm-11.771 6.177c0 .221-.18.402-.403.402h-52.35c-.223 0-.404-.18-.404-.402V74.75h53.157v3.237zM16.856 9.426h66.483c.672 0 1.219.541 1.219 1.206v13.843c0 .804.658 1.456 1.47 1.456.813 0 1.472-.652 1.472-1.456V10.632c0-2.27-1.867-4.118-4.161-4.118H51.852V3.652C51.852 1.64 50.197 0 48.162 0h-8.948c-2.035 0-3.69 1.639-3.69 3.652v2.862H16.855c-.813 0-1.471.652-1.471 1.456 0 .804.658 1.456 1.47 1.456zm21.61-5.774c0-.408.335-.74.748-.74h8.948c.412 0 .748.332.748.74v2.862H38.465V3.652z" />
+                                    <path fill="#000" d="M20.66 50.901c-.79 0-1.43.635-1.43 1.418v12.53c0 .784.64 1.418 1.43 1.418h5.796c.789 0 1.429-.634 1.429-1.418V52.32c0-.783-.64-1.418-1.43-1.418H20.66zm4.367 12.53h-2.939v-9.694h2.94v9.694zM34.121 43.218c-.789 0-1.429.62-1.429 1.385v19.319c0 .765.64 1.385 1.43 1.385h5.795c.79 0 1.43-.62 1.43-1.385V44.603c0-.765-.64-1.385-1.43-1.385h-5.796zm4.368 19.319H35.55V45.988h2.939v16.549zM47.583 50.901c-.79 0-1.43.635-1.43 1.418v12.53c0 .784.64 1.418 1.43 1.418h5.796c.789 0 1.429-.634 1.429-1.418V52.32c0-.783-.64-1.418-1.43-1.418h-5.795zm4.367 12.53h-2.939v-9.694h2.94v9.694zM60.083 59.545c-.79 0-1.43.696-1.43 1.556v4.57c0 .86.64 1.557 1.43 1.557h5.796c.789 0 1.429-.697 1.429-1.557s-.64-1.557-1.43-1.557h-4.367v-3.013c0-.86-.64-1.556-1.428-1.556zM99.252 73.342l-8.41-14.452c2.132-2.253 3.683-5.006 4.512-8.074 1.324-4.904.644-10.027-1.914-14.424-5.282-9.078-17.023-12.198-26.172-6.958-9.149 5.24-12.295 16.89-7.013 25.966 2.56 4.398 6.69 7.543 11.634 8.857 1.65.44 3.325.656 4.99.656 1.454 0 2.9-.166 4.314-.494l8.408 14.452c1.03 1.771 2.907 2.763 4.835 2.763.944 0 1.901-.239 2.777-.74 1.719-.984 2.787-2.82 2.787-4.79 0-.966-.258-1.92-.748-2.762zM72.647 61.448c-4.186-1.113-7.686-3.778-9.853-7.502-4.474-7.688-1.81-17.554 5.94-21.993 2.549-1.46 5.335-2.154 8.086-2.154 5.612 0 11.079 2.888 14.08 8.047 2.168 3.725 2.743 8.063 1.622 12.217-1.122 4.154-3.807 7.626-7.561 9.776-3.754 2.15-8.127 2.721-12.314 1.609zm23.1 16.927c-1.26.722-2.879.292-3.607-.958l-8.089-13.905c.81-.328 1.605-.712 2.376-1.154.772-.442 1.503-.934 2.195-1.467l8.091 13.905c.233.4.355.852.355 1.308 0 .934-.506 1.804-1.32 2.27z" />
+                                    <path fill="#3b36de" d="M90.715 50.087c1.037-3.219.79-6.665-.695-9.704-.345-.707-1.22-1.01-1.953-.677-.734.333-1.048 1.176-.703 1.883 1.172 2.397 1.366 5.117.548 7.658-.823 2.556-2.601 4.7-5.006 6.04-2.545 1.416-5.51 1.792-8.348 1.06-2.839-.734-5.211-2.49-6.68-4.944-3.034-5.066-1.227-11.566 4.027-14.491 3.84-2.139 8.608-1.853 12.145.728.646.471 1.567.349 2.056-.275.49-.623.362-1.511-.285-1.983-4.48-3.269-10.52-3.63-15.385-.922-3.224 1.795-5.53 4.693-6.494 8.16-.963 3.468-.469 7.09 1.393 10.199 1.861 3.109 4.867 5.332 8.463 6.262 1.2.31 2.42.464 3.63.464 2.415 0 4.799-.611 6.946-1.807 3.047-1.696 5.299-4.413 6.341-7.65z" />
+                                </g>
+                            </svg>
+                        </div>
+<h3 id="registro-clinico" class="title">Clinical Records and Patient Follow-up</h3>
+
+                    </div> <!-- WHAT WE DO ITEM -->
+                </div>
+                <div class="col-lg-4 col-md-6 col-sm-8">
+                    <div class="what-we-do-item what-we-do-2-item text-center mt-30">
+                        <div class="icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+                                <g>
+                                    <path fill="#000" d="M13.333 13.333H16.666V16.666H13.333zM20 13.333H23.333V16.666H20zM26.667 13.333H30V16.666H26.667z" />
+                                    <path fill="#000" d="M93.333 0H60c-3.682 0-6.667 2.985-6.667 6.667h-40c-3.682 0-6.666 2.984-6.666 6.666v73.334c0 3.682 2.984 6.666 6.666 6.666h73.334c3.682 0 6.666-2.984 6.666-6.666V30c3.682 0 6.667-2.985 6.667-6.667V6.667C100 2.985 97.015 0 93.333 0zm-80 10h40v10H10v-6.667C10 11.493 11.492 10 13.333 10zM90 86.667C90 88.507 88.508 90 86.667 90H13.333C11.493 90 10 88.508 10 86.667V23.333h43.333C53.333 27.015 56.318 30 60 30h1.667v5c0 .615.338 1.18.88 1.47.542.29 1.2.258 1.711-.083L73.833 30H90v56.667zm6.667-63.334c0 1.841-1.493 3.334-3.334 3.334h-20c-.329 0-.65.098-.925.28L65 31.887v-3.554c0-.92-.746-1.666-1.667-1.666H60c-1.84 0-3.333-1.493-3.333-3.334V6.667c0-1.841 1.492-3.334 3.333-3.334h33.333c1.841 0 3.334 1.493 3.334 3.334v16.666z" />
+                                    <path fill="#3b36de" d="M63.822 7.155l-3.334 3.333c-.65.651-.65 1.706 0 2.357l3.334 3.333 2.356-2.356-2.155-2.155 2.155-2.155-2.356-2.357zM76.178 16.178l3.334-3.333c.65-.65.65-1.706 0-2.357l-3.334-3.333-2.356 2.357 2.155 2.155-2.155 2.155 2.356 2.356z" />
+                                    <path fill="#3b36de" d="M64.729 10L75.271 10 75.271 13.332 64.729 13.332z" transform="rotate(-71.547 70 11.666)" />
+                                    <path fill="#3b36de" d="M83.333 10H86.666V13.333H83.333zM60 20H63.333V23.333H60zM66.667 20H93.334V23.333H66.667zM90 10H93.333V13.333H90zM18.333 31.667h33.334v-3.334h-35c-.92 0-1.667.747-1.667 1.667v18.333c0 .92.746 1.667 1.667 1.667h66.666c.92 0 1.667-.746 1.667-1.667v-15h-3.333v13.334H18.333v-15zM33.333 55H16.667c-.92 0-1.667.746-1.667 1.667v6.666c0 .92.746 1.667 1.667 1.667h16.666c.92 0 1.667-.746 1.667-1.667v-6.666c0-.92-.746-1.667-1.667-1.667zm-1.666 6.667H18.333v-3.334h13.334v3.334zM15 68.333H35V71.666H15zM15 75H35V78.333H15zM15 81.667H30V85H15zM58.333 55H41.667c-.92 0-1.667.746-1.667 1.667v6.666c0 .92.746 1.667 1.667 1.667h16.666c.92 0 1.667-.746 1.667-1.667v-6.666c0-.92-.746-1.667-1.667-1.667zm-1.666 6.667H43.333v-3.334h13.334v3.334zM40 68.333H60V71.666H40zM40 75H60V78.333H40zM40 81.667H55V85H40zM83.333 55H66.667c-.92 0-1.667.746-1.667 1.667v6.666c0 .92.746 1.667 1.667 1.667h16.666c.92 0 1.667-.746 1.667-1.667v-6.666c0-.92-.746-1.667-1.667-1.667zm-1.666 6.667H68.333v-3.334h13.334v3.334zM65 68.333H85V71.666H65zM65 75H85V78.333H65zM65 81.667H80V85H65zM40 96.667H86.667V100H40zM33.333 96.667H36.666V100H33.333zM0 23.333H3.333V66.666H0z" />
+                                </g>
+                            </svg>
+                        </div>
+                        
+<h3 id="interfaz-clinica" class="title">Intuitive, Easy-to-Use Medical Interface</h3>
+
+                    </div> <!-- WHAT WE DO ITEM -->
+                </div>
+                <div class="col-lg-4 col-md-6 col-sm-8">
+                    <div class="what-we-do-item what-we-do-2-item text-center mt-30">
+                        <div class="icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="99" viewBox="0 0 100 99">
+                                <g fill="none">
+                                    <path fill="#000" d="M53.112 71.458c0-10.447-8.499-18.946-18.946-18.946-10.446 0-18.945 8.5-18.945 18.946 0 10.447 8.499 18.946 18.945 18.946 10.447 0 18.946-8.5 18.946-18.946zm-33.985 0c0-8.293 6.746-15.04 15.039-15.04s15.04 6.747 15.04 15.04-6.747 15.04-15.04 15.04-15.04-6.747-15.04-15.04z" />
+                                    <path fill="#3b36de" d="M49.291 44.904l3.93 6.806c.488.847 1.528 1.202 2.433.83l3.349-1.375c.607.415 1.244.783 1.906 1.102l.484 3.587c.13.969.958 1.692 1.936 1.692h7.858c.978 0 1.805-.723 1.936-1.692l.484-3.587c.662-.319 1.299-.687 1.906-1.102l3.35 1.375c.904.371 1.944.017 2.433-.83l3.929-6.806c.489-.846.276-1.924-.497-2.522l-2.865-2.212c.055-.733.055-1.47 0-2.203l2.865-2.213c.773-.597.986-1.675.497-2.522l-3.93-6.806c-.488-.846-1.528-1.201-2.433-.83l-3.349 1.375c-.607-.415-1.244-.783-1.906-1.102l-.484-3.587c-.13-.969-.958-1.692-1.936-1.692H63.33c-.978 0-1.805.723-1.936 1.692l-.484 3.587c-.662.32-1.299.687-1.906 1.102l-3.35-1.375c-.904-.37-1.944-.016-2.432.83l-3.93 6.806c-.489.847-.276 1.925.498 2.522l2.864 2.213c-.055.733-.055 1.47 0 2.203l-2.864 2.212c-.774.597-.987 1.675-.498 2.522zm7.357-4.163c-.173-1.107-.173-2.239 0-3.345.11-.704-.172-1.412-.736-1.848l-2.384-1.841 2.222-3.849 2.79 1.146c.66.27 1.415.16 1.97-.289.872-.705 1.844-1.267 2.89-1.67.665-.257 1.138-.855 1.233-1.562l.403-2.986h4.444l.403 2.986c.095.707.568 1.306 1.233 1.562 1.046.403 2.018.965 2.89 1.67.555.45 1.31.56 1.97.289l2.79-1.146 2.222 3.849-2.384 1.842c-.564.435-.846 1.143-.736 1.847.173 1.107.173 2.239 0 3.345-.11.704.172 1.412.736 1.847l2.384 1.842-2.222 3.849-2.79-1.146c-.66-.27-1.415-.16-1.97.289-.871.705-1.844 1.267-2.89 1.67-.665.256-1.138.855-1.233 1.561l-.403 2.987h-4.444l-.403-2.987c-.095-.706-.568-1.305-1.233-1.561-1.046-.403-2.018-.965-2.89-1.67-.555-.45-1.31-.56-1.97-.289l-2.79 1.145-2.222-3.848 2.385-1.842c.563-.435.845-1.143.735-1.847z" />
+                                    <path fill="#000" d="M67.258 46.199c3.932 0 7.131-3.199 7.131-7.131 0-3.932-3.199-7.131-7.131-7.131-3.932 0-7.131 3.199-7.131 7.131 0 3.932 3.199 7.131 7.131 7.131zm0-10.356c1.778 0 3.225 1.447 3.225 3.225s-1.447 3.225-3.225 3.225-3.225-1.447-3.225-3.225 1.447-3.225 3.225-3.225zM22.267 46.251c-.3 1.036.296 2.12 1.332 2.42 1.022.296 2.123-.31 2.42-1.333 2.05-7.073 7.185-12.765 13.831-15.587l-.974 2.214c-.435.987.013 2.14 1 2.574.257.113.523.166.786.166.751 0 1.467-.435 1.789-1.167l2.73-6.203c.39-.884.051-1.953-.772-2.455l-5.68-3.457c-.921-.56-2.123-.269-2.684.653-.56.921-.268 2.123.653 2.684l2.023 1.231c-7.907 3.217-14.033 9.908-16.454 18.26zM80.217 63.27c.3-1.037-.296-2.12-1.332-2.42-1.036-.3-2.12.296-2.42 1.332-2.05 7.073-7.185 12.765-13.83 15.588l.974-2.215c.434-.987-.014-2.14-1.001-2.574-.988-.435-2.14.014-2.575 1l-2.73 6.204c-.39.885-.053 1.954.772 2.455l5.68 3.457c.317.193.667.285 1.014.285.659 0 1.302-.333 1.67-.938.56-.921.268-2.123-.653-2.684l-2.023-1.231c7.908-3.216 14.034-9.908 16.454-18.26z" />
+                                    <path fill="#000" d="M99.99 7.454v-.022C99.78 3.305 96.31.009 92.079.009H7.826C3.562.021-.002 3.56 0 7.836v82.391c.006 4.305 3.568 7.808 7.94 7.808h.04c1.078 0 1.953-.875 1.953-1.954 0-1.078-.875-1.953-1.953-1.953h-.04c-2.184 0-4.03-1.789-4.034-3.903V17.03h92.188V90.21c.002 2.134-1.78 3.917-3.913 3.917-22.536.012-65.328.029-66.947.002-.06-.002-.12-.003-.182 0-1.078.047-1.913.96-1.865 2.037.003.076.104 1.854 2.128 1.87l66.867-.003c4.263 0 7.823-3.561 7.818-7.825V7.818c0-.122-.004-.243-.01-.364zm-3.896 5.67H3.906v-5.29c0-2.132 1.79-3.919 3.92-3.919h84.238c2.184 0 4.03 1.795 4.03 3.92v5.289z" />
+                                    <path fill="#000" d="M10.614 6.303c-.814.06-1.519.638-1.737 1.426-.486 1.754 1.585 3.162 3.044 2.088.712-.524.979-1.5.64-2.314-.316-.77-1.117-1.263-1.947-1.2zM17.053 6.446c-.983.408-1.466 1.565-1.057 2.549.408.982 1.565 1.465 2.549 1.056.987-.41 1.461-1.563 1.057-2.55-.409-.98-1.566-1.463-2.55-1.055zM24.094 6.446c-.984.408-1.464 1.564-1.057 2.549.407.984 1.566 1.462 2.549 1.056.987-.407 1.46-1.565 1.057-2.55-.409-.981-1.566-1.463-2.55-1.055zM17.55 94.458c-.75-.5-1.776-.413-2.43.209-.567.54-.756 1.392-.472 2.122.626 1.604 2.964 1.632 3.623.039.35-.846.05-1.866-.72-2.37z" />
+                                    <path fill="#3b36de" d="M35.552 81.361v-.906c2.272-.61 3.728-2.564 4.052-4.492.422-2.512-.94-4.781-3.392-5.648-.217-.077-.439-.156-.66-.238v-4.14c.38.163.598.347.618.365l-.017-.016s1.261.88 2.084-.17c.891-1.135-.097-1.983-.097-1.983-.487-.45-1.398-1.005-2.588-1.251v-.68c0-.808-.656-1.464-1.465-1.464s-1.465.656-1.465 1.465v.779c-.062.016-.124.033-.186.052-1.657.499-2.894 1.912-3.229 3.688-.307 1.632.225 3.214 1.389 4.127.53.416 1.173.797 2.026 1.192v5.605c-.551-.096-.994-.305-1.671-.748-.678-.443-1.585-.253-2.028.424-.443.677-.253 1.585.424 2.028 1.24.812 2.15 1.133 3.275 1.245v.766c0 .809.656 1.465 1.465 1.465.81 0 1.465-.656 1.465-1.465zm1.163-5.884c-.113.67-.506 1.371-1.163 1.808v-4.074c1.28.616 1.246 1.772 1.163 2.266zm-4.31-6.933c-.296-.232-.421-.734-.318-1.28.065-.344.236-.735.536-1.03v2.469c-.077-.053-.15-.105-.219-.16z" />
+                                </g>
+                            </svg>
+
+                        </div>
+<h3 id="automatizacion-consultas" class="title">Automation for Medical Visits and Appointments</h3>
+
+                    </div> <!-- WHAT WE DO ITEM -->
+                </div>
+                <div class="col-lg-4 col-md-6 col-sm-8">
+                    <div class="what-we-do-item what-we-do-2-item text-center mt-30">
+                        <div class="icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+                                <g fill="none">
+                                    <path fill="#000" d="M9.677 90.323L12.903 90.323 12.903 93.548 9.677 93.548zM16.129 90.323L19.355 90.323 19.355 93.548 16.129 93.548zM22.581 90.323L25.806 90.323 25.806 93.548 22.581 93.548zM77.419 90.323L90.323 90.323 90.323 93.548 77.419 93.548z" />
+                                    <path fill="#000" d="M96.774 83.871V30.645c0-4.446-3.618-8.064-8.064-8.064H83.87C83.871 10.129 73.742 0 61.291 0 48.837 0 38.71 10.129 38.71 22.58H11.29c-4.446 0-8.064 3.619-8.064 8.065v53.226H0v8.064C0 96.382 3.618 100 8.065 100h83.87c4.447 0 8.065-3.618 8.065-8.065v-8.064h-3.226zM88.71 25.806c2.667 0 4.838 2.172 4.838 4.84V83.87h-3.225V32.258c0-1.779-1.447-3.226-3.226-3.226H82.92c.31-1.045.535-2.124.693-3.226h5.097zm-45.837-9.152l17.119 7.133 5.861 17.582c-1.466.357-2.988.566-4.563.566-10.673 0-19.355-8.681-19.355-19.354 0-2.068.334-4.059.938-5.927zm26.045 23.709l-5.782-17.347 12.919-12.92c2.858 3.373 4.59 7.728 4.59 12.485 0 7.964-4.839 14.816-11.727 17.782zM61.29 3.226c4.757 0 9.111 1.732 12.486 4.589l-12.861 12.86-16.792-6.994C47.35 7.478 53.827 3.226 61.29 3.226zM6.452 30.646c0-2.668 2.17-4.84 4.838-4.84h27.678c.158 1.102.38 2.181.693 3.226H12.903c-1.779 0-3.226 1.447-3.226 3.226v51.613H6.452V30.645zm90.322 61.29c0 2.667-2.171 4.838-4.839 4.838H8.065c-2.668 0-4.84-2.171-4.84-4.839v-4.838h33.23c2.32 2.085 5.287 3.226 8.43 3.226h10.23c3.145 0 6.112-1.14 8.432-3.226H83.87V83.87H62.235l-.472.472c-1.776 1.776-4.136 2.754-6.649 2.754h-10.23c-2.511 0-4.873-.978-6.648-2.754l-.471-.472H12.903V32.258H40.92c3.633 7.616 11.385 12.903 20.37 12.903 8.985 0 16.737-5.287 20.371-12.903h5.436v54.839h9.677v4.838z" />
+                                    <path fill="#3b36de" d="M79.032 67.742c-.99 0-1.911.302-2.679.814l-5.627-4.219c.143-.456.242-.932.242-1.434 0-2.667-2.172-4.838-4.839-4.838-2.667 0-4.839 2.17-4.839 4.838 0 .555.113 1.08.285 1.578l-9.033 7.227c-.74-.461-1.606-.74-2.542-.74-1.085 0-2.078.372-2.886.977l-6.954-4.637c.096-.379.163-.77.163-1.179 0-2.667-2.172-4.839-4.84-4.839-2.667 0-4.838 2.172-4.838 4.839 0 .41.066.8.163 1.179l-6.955 4.637c-.808-.606-1.8-.977-2.885-.977-2.668 0-4.839 2.171-4.839 4.838 0 2.668 2.171 4.84 4.839 4.84 2.667 0 4.838-2.172 4.838-4.84 0-.41-.066-.8-.163-1.179l6.955-4.637c.808.607 1.8.978 2.886.978 1.085 0 2.077-.371 2.885-.978l6.955 4.637c-.097.38-.163.772-.163 1.18 0 2.667 2.172 4.838 4.839 4.838 2.667 0 4.839-2.171 4.839-4.839 0-.555-.113-1.08-.285-1.577l9.033-7.227c.74.461 1.606.74 2.542.74.99 0 1.911-.302 2.68-.814l5.626 4.219c-.143.456-.241.932-.241 1.434 0 2.667 2.17 4.838 4.838 4.838s4.839-2.17 4.839-4.838-2.171-4.84-4.839-4.84zm-58.064 9.677c-.889 0-1.613-.724-1.613-1.613 0-.888.724-1.612 1.613-1.612.888 0 1.613.724 1.613 1.612 0 .889-.725 1.613-1.613 1.613zm14.516-9.677c-.888 0-1.613-.725-1.613-1.613s.725-1.613 1.613-1.613 1.613.725 1.613 1.613-.725 1.613-1.613 1.613zM50 77.419c-.888 0-1.613-.724-1.613-1.613 0-.888.725-1.612 1.613-1.612s1.613.724 1.613 1.612c0 .889-.725 1.613-1.613 1.613zm16.129-12.903c-.888 0-1.613-.724-1.613-1.613 0-.888.725-1.613 1.613-1.613s1.613.725 1.613 1.613c0 .889-.725 1.613-1.613 1.613zm12.903 9.678c-.888 0-1.613-.725-1.613-1.613 0-.889.725-1.613 1.613-1.613.889 0 1.613.724 1.613 1.613 0 .888-.724 1.613-1.613 1.613z" />
+                                    <path fill="#000" d="M41.935 35.484H16.13v22.58h25.806v-22.58zM38.71 54.839H19.355v-16.13H38.71v16.13z" />
+                                    <path fill="#3b36de" d="M22.581 41.935L35.484 41.935 35.484 45.161 22.581 45.161zM22.581 48.387L35.484 48.387 35.484 51.613 22.581 51.613z" />
+                                    <path fill="#000" d="M45.161 51.613L48.387 51.613 48.387 54.839 45.161 54.839zM51.613 51.613L83.871 51.613 83.871 54.839 51.613 54.839z" />
+                                </g>
+                            </svg>
+
+                        </div>
+<h3 id="registro-clinico" class="title">Technical Support and Real-Time Communication</h3>
+                        
+                    </div> <!-- WHAT WE DO ITEM -->
+                </div>
+                <div class="col-lg-4 col-md-6 col-sm-8">
+                    <div class="what-we-do-item what-we-do-2-item text-center mt-30">
+                        <div class="icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+                                <g fill="none">
+                                    <path fill="#000" d="M33.333 0c-13.807 0-25 11.193-25 25v18.333C8.341 49.773 13.56 54.993 20 55h1.667v-3.333H20c-4.6-.006-8.328-3.734-8.333-8.334V25c0-11.966 9.7-21.667 21.666-21.667C45.3 3.333 55 13.033 55 25v18.333c-.005 4.6-3.733 8.328-8.333 8.334H45V55h1.667c6.44-.007 11.659-5.226 11.666-11.667V25c0-13.807-11.193-25-25-25zM13.735 78.548l1.218-1.918-2.815-1.787-1.218 1.92c-3.685 5.807-3.411 13.284.688 18.805V100h3.334v-5c0-.379-.129-.746-.365-1.042-3.544-4.43-3.882-10.62-.842-15.41z" />
+                                    <path fill="#3b36de" d="M91.667 0H70c-4.6.005-8.328 3.733-8.333 8.333V25c.005 4.6 3.733 8.328 8.333 8.333h3.333V40c0 .674.406 1.282 1.029 1.54.202.084.419.127.638.127.442 0 .866-.176 1.178-.489l7.845-7.845h7.644c4.6-.005 8.328-3.733 8.333-8.333V8.333C99.995 3.733 96.267.005 91.667 0zm5 25c0 2.761-2.239 5-5 5h-8.334c-.442 0-.865.176-1.178.488l-5.488 5.489v-4.31c0-.92-.747-1.667-1.667-1.667h-5c-2.761 0-5-2.239-5-5V8.333c0-2.761 2.239-5 5-5h21.667c2.761 0 5 2.239 5 5V25z" />
+                                    <path fill="#000" d="M70 8.333H81.667V11.666H70zM85 8.333H91.667V11.666H85zM70 15H91.667V18.333H70zM70 21.667H81.667V25H70zM55.747 76.763l-1.219-1.92-2.815 1.787 1.219 1.92c3.04 4.789 2.702 10.98-.842 15.408-.236.296-.365.663-.365 1.042v5h3.333v-4.432c4.1-5.521 4.373-12.998.689-18.805z" />
+                                    <path fill="#000" d="M98.333 56.667h-15c-6.253.007-11.388 4.943-11.643 11.191l-5.023 9.044V70C66.659 63.56 61.44 58.34 55 58.333h-6.092l-.045-.035-.03.035H45c-1.841 0-3.333-1.492-3.333-3.333v-3.922c5.15-2.973 8.325-8.465 8.333-14.411V23.333c-.002-2.761-.69-5.479-2-7.91-.42-.773-1.369-1.087-2.167-.716L17.623 27.98c-.584.275-.957.863-.956 1.508v7.179c.008 5.946 3.183 11.438 8.333 14.411V55c0 1.841-1.492 3.333-3.333 3.333h-10C5.227 58.341.007 63.56 0 70v30h3.333V70c.006-4.6 3.734-8.328 8.334-8.333h5.303l15.008 20.97c.309.43.804.69 1.334.696h.021c.525 0 1.019-.247 1.334-.666l15.833-21H55c4.6.005 8.328 3.733 8.333 8.333v13.333c.001.92.748 1.666 1.668 1.666.605-.001 1.162-.329 1.456-.857L74.313 70h9.555l-16.25 30h3.792l16.257-30h.666c6.44-.007 11.66-5.226 11.667-11.667 0-.92-.746-1.666-1.667-1.666zM20 36.667v-6.12l25.735-12.11c.616 1.559.932 3.22.932 4.896v13.334C46.667 44.03 40.697 50 33.333 50 25.97 50 20 44.03 20 36.667zm13.368 42.186l-5.143-7.186h10.56l-5.417 7.186zm7.939-10.52H25.833l-4.771-6.666h.605c3.682 0 6.666-2.985 6.666-6.667v-2.435c3.255 1.024 6.746 1.024 10 0V55c0 3.682 2.985 6.667 6.667 6.667h1.333l-5.026 6.666zm47.026-1.666H75.167c.797-3.878 4.208-6.663 8.166-6.667H96.5c-.797 3.878-4.208 6.662-8.167 6.667z" />
+                                </g>
+                            </svg>
+
+                        </div>
+<h3 id="gestion-administrativa-medica" class="title">Administrative Management and Medical Billing</h3>
+
+                    </div> <!-- WHAT WE DO ITEM -->
+                </div>
+                <div class="col-lg-4 col-md-6 col-sm-8">
+                    <div class="what-we-do-item what-we-do-2-item text-center mt-30">
+                        <div class="icon">
+                            <svg width="100px" height="100px" viewBox="0 0 100 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
+                                <title>contract</title>
+                                <desc>Created with Sketch.</desc>
+                                <g id="Design" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                                    <g id="01_Saas-Startup_Home" transform="translate(-1296.000000, -5186.000000)" fill-rule="nonzero">
+                                        <g id="What-we-do" transform="translate(0.000000, 4406.000000)">
+                                            <g id="Business-&amp;-Finance" transform="translate(1211.500000, 720.000000)">
+                                                <g id="contract" transform="translate(84.500000, 60.000000)">
+                                                    <path d="M97.4201172,31.4701172 C93.9933594,28.0431641 88.4173828,28.0433594 84.9894531,31.4708984 C83.9351562,32.5261719 77.2037109,39.2630859 76.1753906,40.2923828 L76.1753906,17.0753906 C76.1753906,14.7277344 75.2611328,12.5207031 73.6009766,10.8607422 L65.3148437,2.57421875 C63.6548828,0.9140625 61.4476563,0 59.1,0 L8.79257812,0 C3.94628906,0 0.003515625,3.94277344 0.003515625,8.7890625 L0.003515625,91.2109375 C0.003515625,96.0572266 3.94628906,100 8.79257812,100 L67.3863281,100 C72.2326172,100 76.1753906,96.0572266 76.1753906,91.2109375 L76.1753906,65.1623047 L97.4199219,43.8998047 C100.854883,40.4650391 100.855664,34.9052734 97.4201172,31.4701172 Z M57.4574709,2.72107475 C58.2131223,2.72107475 59.6692312,2.59017144 60.9717567,3.89227282 L72.2841309,15.2035454 C73.5533267,16.4728543 73.4557372,18.8637354 73.4557372,19.7174062 L57.4574709,19.7174062 L57.4574709,2.72107475 Z M72.0894531,92.9800885 C72.0894531,94.6452677 70.7030774,96 68.998544,96 L7.18036222,96 C5.47603494,96 4.08945313,94.6452677 4.08945313,92.9800885 L4.08945313,8.0199115 C4.08945313,6.3547323 5.47603494,4 7.18036222,4 L53.5439986,4 L53.5439986,20.0995575 C53.5439986,21.767354 54.9279016,23.119469 56.6349077,23.119469 L72.0894531,23.119469 L72.0894531,46.5384801 C72.0894531,46.5384801 62.9704471,55.4556748 62.9700349,55.4558761 L58.6009319,59.724823 C58.2617562,60.056208 58.0058289,60.4604735 57.8541683,60.9052058 L53.4827986,73.7176836 C53.1125077,74.8028385 53.4016107,75.9993274 54.2295622,76.8080597 C55.058544,77.618 56.2835743,77.8990531 57.3925925,77.5376704 L70.5062895,73.2669115 C70.9614774,73.1187345 71.3752471,72.8688872 71.7144228,72.5373009 L72.0894531,72.170885 L72.0894531,92.9800885 Z M64.5609438,59 L72,66.4390562 L69.1584089,69.2806473 L58,73 L61.7193527,61.8412404 L64.5609438,59 Z M72.4206956,62.0820932 L67.1887364,57.8066336 C69.721431,55.2492625 80.9698704,43.8905457 83.3554763,41.4815787 L88.5874355,45.7570383 L72.4206956,62.0820932 Z M94.0525833,40.0010738 L90.2882932,43.7683228 L85.1242314,38.6045432 L88.8897388,34.8360771 C90.3143411,33.4122829 92.6304154,33.4125263 94.054044,34.8360771 C95.4774291,36.2601148 95.4849757,38.5685163 94.0525833,40.0010738 Z" id="Shape" fill="#000000"></path>
+                                                    <path d="M55.6675781,29.296875 L14.6519531,29.296875 C13.0339844,29.296875 11.7222656,30.6085938 11.7222656,32.2265625 C11.7222656,33.8445312 13.0339844,35.15625 14.6519531,35.15625 L55.6675781,35.15625 C57.2855469,35.15625 58.5972656,33.8445312 58.5972656,32.2265625 C58.5972656,30.6085938 57.2855469,29.296875 55.6675781,29.296875 Z" id="Path" fill="#3b36de"></path>
+                                                    <path d="M43.9488281,41.015625 L14.6519531,41.015625 C13.0339844,41.015625 11.7222656,42.3273438 11.7222656,43.9453125 C11.7222656,45.5632812 13.0339844,46.875 14.6519531,46.875 L43.9488281,46.875 C45.5667969,46.875 46.8785156,45.5632812 46.8785156,43.9453125 C46.8785156,42.3273438 45.5667969,41.015625 43.9488281,41.015625 Z" id="Path" fill="#3b36de"></path>
+                                                    <path d="M43.9488281,52.734375 L14.6519531,52.734375 C13.0339844,52.734375 11.7222656,54.0460938 11.7222656,55.6640625 C11.7222656,57.2820312 13.0339844,58.59375 14.6519531,58.59375 L43.9488281,58.59375 C45.5667969,58.59375 46.8785156,57.2820312 46.8785156,55.6640625 C46.8785156,54.0460938 45.5667969,52.734375 43.9488281,52.734375 Z" id="Path" fill="#3b36de"></path>
+                                                    <path d="M43.9488281,64.453125 L14.6519531,64.453125 C13.0339844,64.453125 11.7222656,65.7648437 11.7222656,67.3828125 C11.7222656,69.0007813 13.0339844,70.3125 14.6519531,70.3125 L43.9488281,70.3125 C45.5667969,70.3125 46.8785156,69.0007813 46.8785156,67.3828125 C46.8785156,65.7648437 45.5667969,64.453125 43.9488281,64.453125 Z" id="Path" fill="#3b36de"></path>
+                                                    <path d="M55.6675781,82.421875 L38.0894531,82.421875 C36.4714844,82.421875 35.1597656,83.7335937 35.1597656,85.3515625 C35.1597656,86.9695313 36.4714844,88.28125 38.0894531,88.28125 L55.6675781,88.28125 C57.2855469,88.28125 58.5972656,86.9695313 58.5972656,85.3515625 C58.5972656,83.7335937 57.2855469,82.421875 55.6675781,82.421875 Z" id="Path" fill="#000000"></path>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </svg>
+
+                        </div>
+<h3 id="registro-clinico" class="title">Security, Privacy, and Medical Compliance</h3>
+
+                    </div> <!-- WHAT WE DO ITEM -->
+                </div>
+            </div> <!-- row -->
+        </div>
+        <div class="what-we-do-bg">
+            <div class="what-we-do-overlay-1">
+                <img src="assets/images/what-we-do-overlay-3.png" alt="SyncroClinic EHR interface">
+            </div>
+            <div class="what-we-do-overlay-2">
+                <img src="assets/images/what-we-do-overlay-4.png" alt="Attach exams with QR">
+            </div>
+        </div>
+    </section>
+
+    <!--====== WHAT WE DO PART ENDS ======-->
+
+    <!--====== TESTIMONIAL PART START ======-->
+
+    <section class="testimonial-area">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-6 col-md-8">
+                    <div class="section-title section-title-2 text-center">
+<span>Testimonials</span>
+          <h3 class="title">
+            <span>Real Feedback on</span> our <span>Electronic Health Record Software</span>
+          </h3>
+                    </div> <!-- SECTION TITLE -->
+                </div>
+            </div> <!-- row -->
+            <div class="row justify-content-center">
+                <div class="col-lg-4 col-md-6 col-sm-9">
+                    <div class="testimonial-item mt-30">
+                        <img src="assets/images/testimonial-1.jpg" alt="testimonial from clinic user">
+                                 <h3 class="title">Dr. Ana Rodríguez</h3>
+          <span>Vida Sana Clinic</span>
+          <p>
+            “Since we started using this electronic health record software, we have cut consultation time in half and eliminated paperwork. It's intuitive, secure, and accessible from anywhere.”
+          </p>
+                        <div class="icon">
+                            <img src="assets/images/shape.svg" alt="">
+                        </div>
+                    </div> <!-- testimonial item -->
+                </div>
+                <div class="col-lg-4 col-md-6 col-sm-9">
+                    <div class="testimonial-item item-2 mt-30">
+                        <img src="assets/images/testimonial-2.jpg" alt="testimonial from Dr. Daxi Gutierrez">
+                        <h3 class="title">Dra. Daxi Gutierrez</h3>
+          <span>Integral Medical Center</span>
+          <p>
+            “Since adopting SyncroClinic for my daily consultations, I can deliver excellent outpatient care with complete peace of mind. The platform gives me the patient information I need instantly—fast, thorough, and secure—with extensive terminology to capture every detail.
+It lets me request any study or exam right away or schedule it for later, keeping everything organized. Each patient's data is stored in a practical way, so when they return I can see their entire history at a glance.
+I can also record personalized treatment plans with ease. Using this system saves me time and space while giving me the confidence to follow up with my patients efficiently and effectively.”
+          </p>
+                        <div class="icon">
+                            <img src="assets/images/shape.svg" alt="">
+                        </div>
+                    </div> <!-- testimonial item -->
+                </div>
+                <div class="col-lg-4 col-md-6 col-sm-9">
+                    <div class="testimonial-item item-3 mt-30">
+                        <img src="assets/images/testimonial-3.jpg" alt="testimonial from administrative team">
+                        <h3 class="title">Salud Total Clinic</h3>
+          <span>Administrative Team</span>
+          <p>
+            “We used to work in Excel and lost valuable time. With this clinical management software everything is digital, secure, and centralized. It's ideal for small and mid-sized clinics.”
+          </p>
+                        <div class="icon">
+                            <img src="assets/images/shape.svg" alt="">
+                        </div>
+                    </div> <!-- testimonial item -->
+                </div>
+            </div> <!-- row -->
+        </div>
+    </section>
+
+    <!--====== TESTIMONIAL PART ENDS ======-->
+
+    <!--====== FUN FACTS PART START ======-->
+
+    <section class="fun-facts-area fun-facts-2-area">
+        <div class="container">
+            <div class="fun-facts-line">
+                <img src="assets/images/fun-facts-line-2.png" alt="">
+                <div class="row">
+                    <div class="col-lg-3 col-md-6">
+                        <div class="fun-facts-item fun-facts-2-item text-center mt-50 animated wow fadeInUp" data-wow-duration="1500ms" data-wow-delay="0ms">
+                            <div class="icon">
+                                <img src="assets/images/fun-facts-5.svg" alt="">
+                            </div>
+                            <h4 class="title">100%</h4>
+                        <span>Cloud-based and available 24/7</span>
+                        </div> <!-- fun facts item -->
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="fun-facts-item fun-facts-2-item text-center mt-50 animated wow fadeInUp" data-wow-duration="1500ms" data-wow-delay="100ms">
+                            <div class="icon">
+                                <img src="assets/images/fun-facts-6.svg" alt="">
+                            </div>
+                           <h4 class="title">0%</h4>
+                        <span>Complex installations</span>
+                        </div> <!-- fun facts item -->
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="fun-facts-item fun-facts-2-item text-center mt-50 animated wow fadeInUp" data-wow-duration="1500ms" data-wow-delay="200ms">
+                            <div class="icon">
+                                <img src="assets/images/fun-facts-7.svg" alt="">
+                            </div>
+                            <h4 class="title">IA</h4>
+                        <span>Integrated medical assistant</span>
+                        </div> <!-- fun facts item -->
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="fun-facts-item fun-facts-2-item text-center mt-50 animated wow fadeInUp" data-wow-duration="1500ms" data-wow-delay="300ms">
+                            <div class="icon">
+                                <img src="assets/images/fun-facts-8.svg" alt="">
+                            </div>
+                           <h4 class="title">+25</h4>
+                        <span>Automated messages for patients</span>
+                        </div> <!-- fun facts item -->
+                    </div>
+                </div> <!-- row -->
+            </div> 
+        </div>
+        <div class="fun-facts-shaps">
+            <div class="fun-facts-shape-1">
+                <img src="assets/images/what-we-do-overlay-4.png" alt="">
+            </div>
+            <div class="fun-facts-shape-2">
+                <img src="assets/images/what-we-do-overlay-5.png" alt="">
+            </div>
+        </div>
+    </section>
+
+    <!--====== FUN FACTS PART ENDS ======-->
+
+    <!--====== PRICING PART START ======-->
+
+<!--====== MEMBERSHIP PLANS ======-->
+<section class="pricing-area">
+  <div id="precios" class="container">
+    <div class="row justify-content-center">
+      <div class="col-lg-5 col-md-7">
+        <div class="section-title section-title-2 text-center">
+          <span>Membership Plans</span>
+          <h3 class="title"><span>Choose the plan</span> that fits <span>your practice</span></h3>
+        </div>
+      </div>
+    </div>
+
+    <!-- Plan cards -->
+    <div class="row justify-content-center">
+      <!-- PLAN ESSENTIAL -->
+      <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="pricing-item pricing-2-item text-center mt-80">
+          <h3 class="title">Essential</h3>
+          <h1>$10</h1>
+          <span>/user/month</span>
+          <ul>
+            <li>Core features to get started</li>
+            <li>Patient management</li>
+            <li>Email support</li>
+          </ul>
+          <a class="main-btn" href="https://app.syncroclinic.com/register-clinic">Start Free</a>
+        </div>
+      </div>
+
+      <!-- PLAN ENTREPRENEUR -->
+      <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="pricing-item pricing-2-item text-center mt-30 center">
+          <b>Recommended</b>
+          <h3 class="title">Entrepreneur</h3>
+          <h1>$15</h1>
+          <span>/user/month</span>
+          <ul>
+            <li>Everything in Essential</li>
+            <li>Process automation</li>
+            <li>WhatsApp support</li>
+          </ul>
+          <a class="main-btn" href="https://app.syncroclinic.com/register-clinic">Start Free</a>
+        </div>
+      </div>
+
+      <!-- PLAN PROFESSIONAL -->
+      <div class="col-lg-4 col-md-6 col-sm-9">
+        <div class="pricing-item pricing-2-item text-center mt-80">
+          <h3 class="title">Professional</h3>
+          <h1>$20</h1>
+          <span>/user/month</span>
+          <ul>
+            <li>Everything in Entrepreneur</li>
+            <li>Premium features and analytics</li>
+            <li>Priority support 24/7</li>
+          </ul>
+          <a class="main-btn" href="https://app.syncroclinic.com/register-clinic">Start Free</a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Detailed feature comparison -->
+    <div class="row justify-content-center mt-60">
+      <div class="col-lg-12">
+        <div class="table-responsive pricing-table-wrapper">
+          <table class="table table-bordered align-middle text-center pricing-table">
+            <thead>
+              <tr>
+                <th class="text-start">Feature</th>
+                <th>Essential</th>
+                <th>Entrepreneur</th>
+                <th>Professional</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- Features included in every plan -->
+              <tr>
+                <td class="text-start">Medical history</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Smartphone and desktop version</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Vital signs log</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Attach exams during visits (devices or phone camera)</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Medication prescriptions</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Selectable exam orders</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Medical consultations module</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Role-based users (Doctor, Receptionist, Admin, etc.)</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Printable and downloadable PDF prescriptions</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Complete patient registration</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Cloud security system</td>
+                <td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+
+              <!-- Features with limited availability -->
+              <tr>
+                <td class="text-start">Appointment scheduling module</td>
+                <td class="text-danger fw-bold">✗</td><td class="text-success fw-bold">✓</td><td class="text-success fw-bold">✓</td>
+              </tr>
+              <tr>
+                <td class="text-start">Medical exams module (X-rays, ultrasound, etc.)</td>
+                <td class="text-danger fw-bold">✗</td><td class="text-danger fw-bold">✗</td><td class="text-success fw-bold">✓</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-center mt-15" style="font-size: 14px;">
+          Plans are billed <strong>per user each month</strong>. You can switch plans at any time.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Styles for colors, borders, and shadow -->
+<style>
+  .text-success {
+    color: #28a745 !important;
+    font-weight: bold;
+    font-size: 1.2em;
+  }
+  .text-danger {
+    color: #dc3545 !important;
+    font-weight: bold;
+    font-size: 1.2em;
+  }
+  .pricing-table-wrapper {
+    box-shadow: 0px 4px 20px rgba(0,0,0,0.08);
+    border-radius: 0px;
+    overflow: hidden;
+    background: #fff;
+    padding: 0; /* Remove internal padding */
+  }
+  .pricing-table {
+    margin-bottom: 0; /* Remove table bottom spacing */
+  }
+  .pricing-table thead {
+    background-color: #f8f9fa;
+  }
+  .pricing-table th {
+    font-weight: bold;
+    padding: 15px;
+  }
+  .pricing-table td {
+    padding: 12px;
+    vertical-align: middle;
+  }
+  /* Remove bottom padding from the last row */
+  .pricing-table tr:last-child td {
+    padding-bottom: 12px;
+  }
+  .pricing-table tr:hover {
+    background-color: #f5faff;
+    transition: background 0.2s ease-in-out;
+  }
+</style>
+
+<!--====== END MEMBERSHIP PLANS ======-->
+
+
+
+
+    <!--====== PRICING PART ENDS ======-->
+
+    <!--====== BRAND PART START ======-->
+
+    <div class="brand-area">
+        <div class="container">
+            <div class="row brand-active">
+                <div class="col-lg-3">
+                    <div class="brand-item text-center">
+                        <a href="error.html"><img src="assets/images/brand-2.png" alt=""></a>
+                    </div> <!-- brand item -->
+                </div>
+                <div class="col-lg-3">
+                    <div class="brand-item text-center">
+                        <a href="error.html"><img src="assets/images/brand-2.png" alt=""></a>
+                    </div> <!-- brand item -->
+                </div>
+                <div class="col-lg-3">
+                    <div class="brand-item text-center">
+                        <a href="error.html"><img src="assets/images/brand-2.png" alt=""></a>
+                    </div> <!-- brand item -->
+                </div>
+                <div class="col-lg-3">
+                    <div class="brand-item text-center">
+                        <a href="error.html"><img src="assets/images/brand-2.png" alt=""></a>
+                    </div> <!-- brand item -->
+                </div>
+                <div class="col-lg-3">
+                    <div class="brand-item text-center">
+                        <a href="error.html"><img src="assets/images/brand-2.png" alt=""></a>
+                    </div> <!-- brand item -->
+                </div>
+            </div> <!-- row -->
+        </div>
+    </div>
+
+    <!--====== BRAND PART ENDS ======-->
+
+    <!--====== FAQ PART START ======-->
+
+    <section id="faq" class="faq-area faq-2-area mt-30">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-lg-6 col-md-10">
+                    <div class="section-title section-title-2 text-center">
+          <span>Frequently Asked Questions</span>
+          <h3 class="title"><span>Answers to</span> Common Questions <span>About the Service</span></h3>
+        </div> <!-- SECTION TITLE -->
+                </div>
+            </div> <!-- row -->
+            <div class="row">
+                <div class="col-lg-3">
+                    <div class="faq-btns text-center mt-30">
+                        <ul class="nav nav-pills" id="pills-tab" role="tablist">
+                                    <li class="nav-item" role="presentation">
+              <a class="nav-link active" id="pills-1-tab" data-toggle="pill" href="#pills-1" role="tab" aria-controls="pills-1" aria-selected="true">General</a>
+            </li>
+            <li class="nav-item" role="presentation">
+              <a class="nav-link" id="pills-2-tab" data-toggle="pill" href="#pills-2" role="tab" aria-controls="pills-2" aria-selected="false">Payments</a>
+            </li>
+            <li class="nav-item" role="presentation">
+              <a class="nav-link" id="pills-3-tab" data-toggle="pill" href="#pills-3" role="tab" aria-controls="pills-3" aria-selected="false">Features</a>
+            </li>
+
+                        </ul>
+                    </div> <!-- faq btns -->
+                </div>
+                <div class="col-lg-9">
+                    <div class="tab-content" id="pills-tabContent">
+                        <div class="tab-pane fade show active" id="pills-1" role="tabpanel" aria-labelledby="pills-1-tab">
+                            <div class="faq-accordion-area">
+                                <div class="accrodion-grp" data-grp-name="faq-accrodion">
+                                    <div class="accrodion item-2 active  animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="0ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                            <h4>What is SyncroClinic and how does the medical record work?</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                              <div class="inner">
+                                                <p>SyncroClinic is an online clinical system that helps physicians and clinics manage patients, consultations, prescriptions, exams, and billing quickly and securely from any device with internet access.</p>
+                                                <p>The digital medical record is organized and easy to read. Every patient has a detailed file that displays:</p>
+                                                <ul>
+                                                  <li>Personal and contact information</li>
+                                                  <li>Past consultations with date, diagnosis, and treatment</li>
+                                                  <li>Medical prescriptions issued</li>
+                                                  <li>Exam and study results</li>
+                                                  <li>Preliminary and final diagnoses</li>
+                                                  <li>Clinical evolution and upcoming scheduled visits</li>
+                                                </ul>
+                                                <p>Everything is arranged in intuitive tabs and in chronological order, allowing doctors to review a patient's health status quickly and make informed decisions faster.</p>
+                                              </div>
+                                            <!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion item-2   animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="300ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>Do I need to install anything?</h4>
+                    </div>
+                    <div class="accrodion-content">
+                      <div class="inner">
+                        <p>No. Everything runs in your browser. There is no software to install on your devices—just connect to the internet and log in.</p>
+                      </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                 <h4>Can I try it before paying?</h4>
+                    </div>
+                    <div class="accrodion-content">
+                      <div class="inner">
+                        <p>Yes. We offer a 15-day free trial with no credit card required. During that time you can explore every feature of the platform.</p>
+                      </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What happens after the 15-day trial?</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                                            <p>You can choose a monthly or annual membership plan that fits your needs. If you don't pick a plan, your account will remain inactive until you complete the payment.</p>
+
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                </div>
+                            </div> <!-- faq accordion -->
+                        </div>
+<div class="tab-pane fade" id="pills-2" role="tabpanel" aria-labelledby="pills-2-tab">
+  <div class="faq-accordion-area">
+    <div class="accrodion-grp" data-grp-name="faq-accrodion">
+
+      <div class="accrodion item-2 active animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="0ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>What payment methods do you accept?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>We accept credit cards and PayPal. Choose whichever option is most convenient and secure when you subscribe.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="300ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>Which plans are available?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>We offer plans lasting 3, 6, 9, 12, 18, 24, and 36 months. Pick the term that fits your needs and budget—the longer the plan, the more you save.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>How is the final price calculated?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>Pricing is per user. Each additional user adds to the cost of the chosen plan. For example, if you choose a six-month plan for three users, the total is the monthly user price multiplied by six and by three.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="900ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>Do you run special promotions?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>Yes. Right now we offer a promotion that gives you one additional user for free when you purchase a plan for a single user.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<div class="tab-pane fade" id="pills-3" role="tabpanel" aria-labelledby="pills-3-tab">
+  <div class="faq-accordion-area">
+    <div class="accrodion-grp" data-grp-name="faq-accrodion">
+
+      <div class="accrodion item-2 active animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="0ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>What features does SyncroClinic include for clinic management?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>SyncroClinic lets you maintain a complete medical history for every patient, manage schedules, record exams, issue prescriptions, coordinate future visits, and more—all from a modern platform accessible on any device.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="200ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>How is each patient's medical history organized?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>Each patient has a digital chart organized in tabs for personal data, consultation history, prescriptions, medical exams, and upcoming appointments. Everything is arranged chronologically to streamline the review process.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="300ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>How are medical appointments scheduled?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>The scheduling module lets you set each doctor's working hours in a visual grid. Patients can be booked in seconds and overlapping appointments are prevented.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="400ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>What does the doctor's module include?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>Physicians can view their patient list, conduct visits, write diagnoses, issue prescriptions, request exams, document clinical progress, and schedule follow-up appointments in just a few clicks.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="500ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>What is the patient waiting list?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>It organizes patients who are waiting to be seen. From there, physicians can call them into the visit, prioritize cases, or assign them to another professional if needed.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>What tasks can the receptionist handle?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>The receptionist can register patients, schedule appointments, review basic histories, and keep the daily agenda organized to support continuous, efficient care.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="700ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>What does the medical exams technician module do?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>It lets staff upload exam results manually or attach files from a phone using a patient-specific QR code.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="800ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>How does the AI diagnostic assistant work?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>The physician can click “Consult AI” to receive a suggested diagnosis based on symptoms, history, and uploaded exams. It's an assistive tool that complements the clinician's judgment.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="900ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>Can I issue medical prescriptions in SyncroClinic?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>Yes. You can create prescriptions with detailed instructions, save them to the patient's record, and deliver them as PDFs or printed copies directly from the system.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="1000ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>How do I select medical exams?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>The system provides a list of common exams with filters by type and automated recommendations based on the diagnosis. You can also enter custom exams.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="1100ms">
+        <div class="accrodion-inner">
+          <div class="accrodion-title">
+            <h4>Can I schedule the next consultation?</h4>
+          </div>
+          <div class="accrodion-content">
+            <div class="inner">
+              <p>Yes. When the visit ends, you can book the patient's next appointment by choosing the date and time based on the provider's availability. Everything is saved automatically.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div> <!-- faq accordion -->
+</div>
+
+                        <div class="tab-pane fade" id="pills-4" role="tabpanel" aria-labelledby="pills-4-tab">
+                            <div class="faq-accordion-area">
+                                <div class="accrodion-grp" data-grp-name="faq-accrodion">
+                                    <div class="accrodion item-2 active  animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="0ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion  item-2  animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="300ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                </div>
+                            </div> <!-- faq accordion -->
+                        </div>
+                        <div class="tab-pane fade" id="pills-5" role="tabpanel" aria-labelledby="pills-5-tab">
+                            <div class="faq-accordion-area">
+                                <div class="accrodion-grp" data-grp-name="faq-accrodion">
+                                    <div class="accrodion item-2 active  animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="0ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion  item-2  animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="300ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                    <div class="accrodion item-2 animated wow fadeInRight" data-wow-duration="1500ms" data-wow-delay="600ms">
+                                        <div class="accrodion-inner">
+                                            <div class="accrodion-title">
+                                                <h4>What If They Let You Run The Hubble</h4>
+                                            </div>
+                                            <div class="accrodion-content">
+                                                <div class="inner">
+                                                    <p>When the weather outside warms up, the kitchen can be a terrible place to be. There are many things you can do however, when it comes to cooking a nice home made meal that doesn’t require traditional stove top or oven cooking. Learn to utilize some of the lesser heat producing equipment in your kitchen, such as the crock pot, in order to truly beat the summer heat and keep your cool while preparing a nice hot meal for friends and family.</p>
+                                                </div><!-- /.inner -->
+                                            </div>
+                                        </div><!-- /.accrodion-inner -->
+                                    </div>
+                                </div>
+                            </div> <!-- faq accordion -->
+                        </div>
+                    </div>
+                </div>
+            </div> <!-- row -->
+        </div>
+    </section>
+
+    <!--====== FAQ PART ENDS ======-->
+
+<!--====== SUBSCRIBE PART START ======-->
+<div id="demo" class="subscribe-area">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="subscribe-content text-center">
+                    <h3 class="title">Ready to implement SyncroClinic in your clinic?</h3>
+<p style="color: white !important;">Book a free meeting and discover how our system can optimize your medical operations.</p>
+                    <a class="main-btn" href="/contact">Schedule a meeting</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="subscribe-bg">
+        <div class="subscribe-shape-1"></div>
+    </div>
+</div>
+<!--====== SUBSCRIBE PART ENDS ======-->
+
+
+    <!--====== FOOTER PART START ======-->
+<footer class="footer-area footer-2-area">
+  <div class="container">
+    <div class="footer-items">
+      <div class="row">
+        <div class="col-lg-3 col-md-6">
+          <div class="footer-about-1 mt-30">
+            <a href="index.html">
+              <img src="assets/images/logo-2.png" alt="SyncroClinic" style="max-width: 180px;">
+            </a>
+            <p style="margin-top: 15px;">
+              Running your clinic with loose papers or scattered files costs time, money, and patients.
+              With <strong>SyncroClinic</strong>, turn your medical operations into a digital, agile, and professional experience.
+              Start free and take full control of your practice!
+            </p>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 col-sm-6">
+          <div class="footer-list mt-30">
+            <h3 class="title">Features</h3>
+            <ul>
+              <li>✔️ Digital medical history</li>
+              <li>✔️ WhatsApp reminders</li>
+              <li>✔️ AI assistant</li>
+              <li>✔️ Appointments, prescriptions, and payments in one place</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6 col-sm-6">
+          <div class="footer-list mt-30 ml-70">
+            <h3 class="title">Navigation</h3>
+            <ul>
+              <li><a href="index.html">Home</a></li>
+              <li><a href="#demo">Request demo</a></li>
+              <li><a href="#precios">Plans &amp; pricing</a></li>
+              <li><a href="#faq">FAQs</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="col-lg-3 col-md-6">
+          <div class="footer-about mt-30">
+            <h3 class="title">Contact</h3>
+            <p>SyncroClinic is a brand of Vozocial S.A., registered in Panama City.</p>
+            <p style="margin-top: 10px;"><strong>Address:</strong> Via Ricardo J. Alfaro, Century Tower</p>
+            <p><strong>WhatsApp:</strong> <a href="https://wa.me/50760708205" target="_blank">+507 6070-8205</a></p>
+            <p><strong>Email:</strong> <a href="mailto:info@syncroclinic.com">info@syncroclinic.com</a></p>
+            <div class="social-icons mt-3">
+              <a href="#"><i class="lni lni-facebook-filled"></i></a>
+              <a href="#"><i class="lni lni-instagram-filled"></i></a>
+              <a href="#"><i class="lni lni-linkedin-original"></i></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-lg-12 text-center">
+        <div class="footer-copyright">
+          <p>© 2026 <strong>SyncroClinic</strong>. All rights reserved.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+<!--====== FOOTER PART ENDS ======-->
+
+
+    <!--====== BACK TO TOP START ======-->
+
+    <a class="back-to-top back-to-top-2">
+        <i class="fal fa-angle-up"></i>
+    </a>
+
+    <!--====== BACK TO TOP ENDS ======-->
+
+
+
+
+
+
+
+    <!--====== jquery js ======-->
+    <script src="assets/js/vendor/modernizr-3.6.0.min.js"></script>
+    <script src="assets/js/vendor/jquery-1.12.4.min.js"></script>
+
+    <!--====== Bootstrap js ======-->
+    <script src="assets/js/bootstrap.min.js"></script>
+    <script src="assets/js/popper.min.js"></script>
+
+    <!--====== magnific popup js ======-->
+    <script src="assets/js/jquery.magnific-popup.min.js"></script>
+
+    <!--====== wow js ======-->
+    <script src="assets/js/wow.js"></script>
+
+    <!--====== Slick js ======-->
+    <script src="assets/js/slick.min.js"></script>
+
+    <!--====== counterup js ======-->
+    <script src="assets/js/jquery.counterup.min.js"></script>
+    <script src="assets/js/waypoints.min.js"></script>
+
+    <!--====== Main js ======-->
+    <script src="assets/js/main.js"></script>
+<style>
+.header-nav {
+  padding-top: 0 !important;
+}
+
+.what-we-do-item a:hover {
+  color: #3b36de; /* or your theme color */
+}
+
+
+.what-we-do-item a {
+  display: block;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1f1f1f;
+  line-height: 1.4;
+  margin-top: 15px;
+  word-break: break-word;
+  text-align: center;
+  max-width: 220px; /* forces text to wrap onto two lines */
+  margin-left: auto;
+  margin-right: auto;
+  white-space: normal;
+}
+@media (max-width: 768px) {
+  .tagline-mobile {
+    font-size: 15px !important; /* one third of 20px */
+  }
+}
+
+  .advertiser-thumb .thumb img[alt="advertiser"] {
+    display: none !important;
+  }
+</style>
+</body>
+
+</html>
+
+


### PR DESCRIPTION
## Summary
- add a new `index-en.html` that localizes the landing page metadata, navigation, hero copy, and primary calls to action in English
- translate the services, pricing, testimonial, FAQ, and footer content so the English homepage is fully localized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d184212b98832b8862183db033845a